### PR TITLE
Fix: в описании

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,9 +18,10 @@
         tools:targetApi="31">
         <activity
             android:name=".ui.root.RootActivity"
-            android:exported="true"
             android:configChanges="orientation"
+            android:exported="true"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustNothing"
             tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/adapter/VacancyAdapter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/adapter/VacancyAdapter.kt
@@ -62,7 +62,8 @@ class VacancyAdapter : RecyclerView.Adapter<VacancyAdapter.VacancyViewHolder>() 
                 Glide.with(itemView)
                     .load(vacancy.logoUrl90)
                     .placeholder(R.drawable.image_placeholder)
-                    .transform(CenterCrop(),
+                    .transform(
+                        CenterCrop(),
                         RoundedCorners(
                             TypedValue.applyDimension(
                                 TypedValue.COMPLEX_UNIT_DIP,

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/adapter/VacancyAdapter.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/adapter/VacancyAdapter.kt
@@ -9,6 +9,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.domain.models.Salary
@@ -61,8 +62,7 @@ class VacancyAdapter : RecyclerView.Adapter<VacancyAdapter.VacancyViewHolder>() 
                 Glide.with(itemView)
                     .load(vacancy.logoUrl90)
                     .placeholder(R.drawable.image_placeholder)
-                    .centerCrop()
-                    .transform(
+                    .transform(CenterCrop(),
                         RoundedCorners(
                             TypedValue.applyDimension(
                                 TypedValue.COMPLEX_UNIT_DIP,

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/ui/filter/settings/FilterSettingsFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/ui/filter/settings/FilterSettingsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
@@ -32,6 +33,7 @@ class FilterSettingsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupListeners()
+        addCallback()
 
         binding.apply {
             salaryField.addTextChangedListener(
@@ -110,6 +112,7 @@ class FilterSettingsFragment : Fragment() {
         setupButtonListeners()
         binding.apply {
             toolbar.setOnClickListener {
+                viewModel.saveFilterParameters()
                 findNavController().popBackStack()
             }
             textViewArea.setOnClickListener {
@@ -131,6 +134,7 @@ class FilterSettingsFragment : Fragment() {
         binding.apply {
             enterFilter.setOnClickListener {
                 viewModel.saveFilterParameters()
+                findNavController().popBackStack()
             }
             resetFilter.setOnClickListener {
                 viewModel.resetFilterParameters()
@@ -185,6 +189,16 @@ class FilterSettingsFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun addCallback() {
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, object :
+            OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                viewModel.saveFilterParameters()
+                findNavController().popBackStack()
+            }
+        })
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/ru/practicum/android/diploma/presentation/ui/vacancy/VacancyFragment.kt
+++ b/app/src/main/java/ru/practicum/android/diploma/presentation/ui/vacancy/VacancyFragment.kt
@@ -2,6 +2,7 @@ package ru.practicum.android.diploma.presentation.ui.vacancy
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,6 +10,8 @@ import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import ru.practicum.android.diploma.R
 import ru.practicum.android.diploma.databinding.FragmentVacancyBinding
@@ -85,6 +88,16 @@ class VacancyFragment : Fragment() {
         Glide.with(this)
             .load(vacancy.logoUrl90)
             .placeholder(R.drawable.image_placeholder)
+            .transform(
+                CenterCrop(),
+                RoundedCorners(
+                    TypedValue.applyDimension(
+                        TypedValue.COMPLEX_UNIT_DIP,
+                        ROUNDED_CORNERS_IMAGE_VACANCY,
+                        requireContext().resources.displayMetrics
+                    ).toInt()
+                )
+            )
             .into(binding.vacancyImage)
 
         binding.vacancyCompanyTitle.text = vacancy.employerName
@@ -213,7 +226,7 @@ class VacancyFragment : Fragment() {
     }
 
     companion object {
-        fun newInstance() = VacancyFragment()
         private const val KEY_VACANCY = "KEY_VACANCY"
+        private const val ROUNDED_CORNERS_IMAGE_VACANCY = 12F
     }
 }

--- a/app/src/main/res/layout/vacancy_item_view.xml
+++ b/app/src/main/res/layout/vacancy_item_view.xml
@@ -5,8 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@null"
-    android:paddingVertical="8dp"
-    android:paddingHorizontal="@dimen/_16dp">
+    android:paddingHorizontal="@dimen/_16dp"
+    android:paddingVertical="8dp">
 
     <ImageView
         android:id="@+id/vacancyImage"


### PR DESCRIPTION
Fix:
- масштабирование image_vacancy
- клавиатура всегда скрывает нижнюю панель
- нажатие "применить" возвращает на экран поиска
- addcallback + toolbar сохраняют фильтр 
Осталось пофиксить - при возвращении через addCallBack или toolBar тоже применяется новый фильтр к текущему запросу